### PR TITLE
Revert "Rework ansible role jkirk.users + implement user_groups"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ repos:
       - id: check-yaml
       - id: check-added-large-files
   - repo: https://github.com/ansible-community/ansible-lint.git
-    rev: v24.9.2
+    rev: v25.12.1
     hooks:
       - id: ansible-lint
+        language_version: python3.11

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,21 +1,17 @@
 ---
-# The users you want to create (mandatory).
+# The users you want to create.
 # users: [ "jane_doe", "john_doe" ]
 
-# Create primary user group (mandatory).
-# We do not use a user group (ie. john_doe:john_doe) anymore.
-# Instead, the user will be a part of this primary user group.
-#
-# groupname: 'sysadmin'
-
-# Put users into additional groups (optional).
-# If the additional groups do not exist, the groups are created.
-# user_groups: [ "adm', 'mygroup' ]
-
-# Set the default shell for new and existing users (optional).
+# Set the default shell for new and existing users.
 # If user_shell is omitted the default shell of existing users is not changed and
 # the default system shell is used for new users.
 # user_shell: '/bin/zsh'
+
+# Create additional user groups. The user you create will
+# automatically be a part of their user's group, ie. john_doe:john_doe.
+#
+# groupname is mandatory when admin is true.
+# groupname: 'sysadmin'
 
 # If `admin` is set to true passwordless sudo for the given groupname is set up
 admin: false

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: A simple ansible role to bootstrap user accounts with SSH key based logins and passwordless sudo.
   company: SynPro Solutions
   role_name: user
-  namespace: synpro
+  namespace: jkirk
 
   license: MIT
 
@@ -29,6 +29,7 @@ galaxy_info:
       versions:
         - "buster"
         - "bullseye"
+        - "bookworm"
 
   galaxy_tags: []
 

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -4,7 +4,7 @@
   tasks:
     - name: "Deploy admin user sysadmin in sysadmin group"
       ansible.builtin.include_role:
-        name: "ansible-role-user"
+        name: jkirk.user
       vars:
         users: ["sysadmin"]
         groupname: "admin"

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -9,11 +9,3 @@
         users: ["sysadmin"]
         groupname: "admin"
         admin: True
-    - name: "Deploy admin user sysadmin in sysadmin group + additional groups 'adm' + 'mygroup1'"
-      ansible.builtin.include_role:
-        name: "ansible-role-user"
-      vars:
-        users: ["sysadmin"]
-        groupname: "admin"
-        user_groups: ["adm", "mygroup1"]
-        admin: True

--- a/tasks/create_group.yml
+++ b/tasks/create_group.yml
@@ -1,0 +1,7 @@
+---
+
+- name: "Create group {{ groupname }}"
+  ansible.builtin.group: name={{ groupname }} state=present
+- name: "Put users in group {{ groupname }}"
+  ansible.builtin.user: name={{ item }} groups={{ groupname }} append=yes
+  with_items: "{{ users }}"

--- a/tasks/create_sudoers.yml
+++ b/tasks/create_sudoers.yml
@@ -1,9 +1,4 @@
 ---
 - name: "Install sudoers file for group {{ groupname }}"
-  ansible.builtin.template:
-    src: templates/etc_sudoers.d/admin.j2
-    dest: "/etc/sudoers.d/{{ groupname }}"
-    owner: root
-    group: root
-    mode: 0440
+  ansible.builtin.template: src=templates/etc_sudoers.d/admin.j2 dest=/etc/sudoers.d/{{ groupname }} owner=root group=root mode=0440
   when: admin

--- a/tasks/create_user.yml
+++ b/tasks/create_user.yml
@@ -1,46 +1,17 @@
 ---
-- name: "Create primary group {{ groupname }}"
-  ansible.builtin.group:
-    name: "{{ groupname }}"
-    state: present
-
-- name: "Create additional groups {{ user_groups }}"
-  ansible.builtin.group:
-    name: "{{ item }}"
-    state: present
-  loop: "{{ user_groups }}"
-  when: user_groups is defined
-
-- name: "Create user account for {{ user_item }}"
-  ansible.builtin.user:
-    name: "{{ user_item }}"
-    group: "{{ groupname }}"
-
-- name: "Put users in groups {{ user_groups }}"
-  ansible.builtin.user:
-    name: "{{ user_item }}"
-    groups: "{{ user_groups }}"
-    append: yes
-  when: user_groups is defined
-
-- name: "Set shell for user {{ user_item }}"
-  ansible.builtin.user:
-    name: "{{ user_item }}"
-    shell: "{{ user_shell }}"
+- name: "Create user group {{ item }}"
+  ansible.builtin.group: name={{ item }} state=present
+- name: "Create user account for {{ item }}"
+  ansible.builtin.user: name={{ item }} group={{ item }}
+- name: "Set shell for user {{ item }}"
+  ansible.builtin.user: name={{ item }} shell={{ user_shell }}
   when: user_shell is defined
-
-- name: "Create directory ssh directory for user {{ user_item }}"
-  ansible.builtin.file:
-    path: "/home/{{ user_item }}/.ssh"
-    state: directory
-    owner: "{{ user_item }}"
-    group: "{{ groupname }}"
-    mode: 0700
-
-- name: "Install authorized_keys file for user {{ user_item }}"
+- name: "Create directory ssh directory for user {{ item }}"
+  ansible.builtin.file: path=/home/{{ item }}/.ssh state=directory owner={{ item }} group={{ item }} mode=0700
+- name: "Install authorized_keys file for user {{ item }}"
   ansible.builtin.copy:
-    src: "ssh/{{ user_item }}.pub"
-    dest: "/home/{{ user_item }}/.ssh/authorized_keys"
-    owner: "{{ user_item }}"
-    group: "{{ groupname }}"
+    src: "ssh/{{ item }}.pub"
+    dest: "/home/{{ item }}/.ssh/authorized_keys"
+    owner: "{{ item }}"
+    group: "{{ item }}"
     mode: 0644

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,17 +11,14 @@
 #   vars:
 #     users: [ 'username1', 'username2' ]
 #     groupname: mygroup
-#     groups: [ 'mygroup1', 'mygroup2' ]
 #     admin: true
 #
 # The usernames are given by a list and the groupname is set. The variable
 # 'admin' defines if the group has sudoers rights.
 #
 
-- name: Include create_user.yml
-  ansible.builtin.include_tasks: create_user.yml
-  loop: "{{ users | flatten(levels=1) }}"
-  loop_control:
-    loop_var: user_item
-- name: Include create_sudoers.yml
-  ansible.builtin.import_tasks: create_sudoers.yml
+- include_tasks: create_user.yml
+  with_items: "{{ users }}"
+- import_tasks: create_group.yml
+  when: groupname is defined
+- import_tasks: create_sudoers.yml

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,0 +1,1 @@
+localhost

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - ansible-role-user


### PR DESCRIPTION
This reverts commit https://github.com/jkirk/ansible-role-user/commit/57abbd1900dc3c6193c06e32137d7659592ef60f.

Note,  that the "user_groups" feature was implicitly added with that commit. It has to be re-implemented, see: #3.

This also reverts "molecule converge update" where we tested
"user_groups", see: https://github.com/jkirk/ansible-role-user/commit/4abc44c1ddba5346351feb420d7a9e0bdcf35884 and https://github.com/jkirk/ansible-role-user/commit/0b01edd35e2e551efc84f3b3940f4bcd47b45a54.

In https://github.com/jkirk/ansible-role-user/commit/aca6d78c38fb134218d5aafe56b956cfc1312b7d we changed the group ownership of the authorized_keys file
from the username group to the new primary group. While doing so we
implicitly fixed an issue where the file was deployed multiple time.

So this only partly reverts https://github.com/jkirk/ansible-role-user/commit/aca6d78c38fb134218d5aafe56b956cfc1312b7d and we take over that fix and we now
deploy the authorized_keys while we create the users and do not iterate
through all the users multiple times.

Issue: https://github.com/jkirk/ansible-role-user/issues/5

This PR also changes the namespace to jkirk as this is what we currently use also makes the Github Workflow Ansible Molecule happy.
(There seem to be issues in Lint Code Base Workflow, which will be fixed separately).